### PR TITLE
reusable-zizmor: add GH_TOKEN to enable online audits

### DIFF
--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -37,6 +37,8 @@ jobs:
 
     - name: Analyze GitHub Actions and workflow definitions with zizmor 🌈
       run: uvx zizmor --format=sarif . > results.sarif
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Upload SARIF report into the GitHub repo code scanning
       uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
CC @webknjaz -- do you think this should be unconditional, or do you want this to be controlled by an `online` input or similar?

Closes #1.

