### PR TITLE
Set `FORCE_COLOR` environment variable to `3` instead of `1`

### DIFF
--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -10,7 +10,7 @@ on:
   workflow_call:
 
 env:
-  FORCE_COLOR: 1  # Request colored output from CLI tools supporting it
+  FORCE_COLOR: 3  # Request colored output from CLI tools supporting it
   PIP_DISABLE_PIP_VERSION_CHECK: 1  # Hide "there's a newer pip" message
   PIP_NO_PYTHON_VERSION_WARNING: 1  # Hide "this Python is deprecated" message
   PIP_NO_WARN_SCRIPT_LOCATION: 1  # Hide "script dir is not in $PATH" message


### PR DESCRIPTION
<!--
    Thank you for opening a PR!
    Please make sure to fill out the sections below.
-->

## Pre-submission checks

Please check these boxes:

- [x] **Mandatory**: This PR corresponds to an issue (if not, please create
      one first).

- [ ] Having read the [AI policy], I hereby disclose the use of an LLM or other
      AI coding assistant in the creation of this PR. PRs will not be rejected
      for using AI tools, but *will* be rejected for undisclosed use or
      use that violates the policy.

[AI policy]: https://github.com/zizmorcore/.github/blob/main/AI_POLICY.md

If a checkbox is not applicable, you can leave it unchecked.

## Summary

<!-- Provide a summary of what your change does. -->

Hi! I would like to recommend using `FORCE_COLOR: 3` over `FORCE_COLOR: 1`. I don't exactly recall why this was the case, but what I do remember is that this enables a wider colour gamut on GHA terminals, and it forces colour output by overriding what tools set, see discussion in https://github.com/Textualize/rich/issues/2425. See also: https://github.com/chalk/supports-color#api, 

It's also what the Scientific Python development guide recommends: https://learn.scientific-python.org/development/guides/tasks/#installing